### PR TITLE
Merge: Campgrounds Cluster Map Feature

### DIFF
--- a/public/js/clusterMap.js
+++ b/public/js/clusterMap.js
@@ -4,7 +4,7 @@ mapboxgl.accessToken = mapToken;
 const map = new mapboxgl.Map({
   container: "map",
   // Choose from Mapbox's core styles, or make your own style with Mapbox Studio
-  style: "mapbox://styles/mapbox/dark-v11",
+  style: "mapbox://styles/mapbox/light-v11",
   center: [-103.5917, 40.6699],
   zoom: 3,
 });
@@ -31,11 +31,11 @@ map.on("load", () => {
     paint: {
       // Use step expressions (https://docs.mapbox.com/style-spec/reference/expressions/#step)
       // with three steps to implement three types of circles:
-      //   * Blue, 20px circles when point count is less than 100
-      //   * Yellow, 30px circles when point count is between 100 and 750
-      //   * Pink, 40px circles when point count is greater than or equal to 750
-      "circle-color": ["step", ["get", "point_count"], "#51bbd6", 100, "#f1f075", 750, "#f28cb1"],
-      "circle-radius": ["step", ["get", "point_count"], 20, 100, 30, 750, 40],
+      //   * Blue, 20px circles when point count is less than 10
+      //   * Yellow, 30px circles when point count is between 10 and 30
+      //   * Pink, 40px circles when point count is greater than or equal to 30
+      "circle-color": ["step", ["get", "point_count"], "#51bbd6", 10, "#f1f075", 30, "#f28cb1"],
+      "circle-radius": ["step", ["get", "point_count"], 15, 10, 20, 30, 25], // [step, size, step, size, size for everything greater than 30]
     },
   });
 

--- a/public/js/clusterMap.js
+++ b/public/js/clusterMap.js
@@ -52,13 +52,13 @@ map.on("load", () => {
   });
 
   map.addLayer({
-    id: "unclustered-point",
+    id: "unclustered-point", //unclustered meaning singled out
     type: "circle",
     source: "campgrounds",
     filter: ["!", ["has", "point_count"]],
     paint: {
       "circle-color": "#11b4da",
-      "circle-radius": 4,
+      "circle-radius": 6,
       "circle-stroke-width": 1,
       "circle-stroke-color": "#fff",
     },
@@ -87,6 +87,7 @@ map.on("load", () => {
   map.on("click", "unclustered-point", (e) => {
     console.log(e.features);
     const coordinates = e.features[0].geometry.coordinates.slice();
+
     const mag = e.features[0].properties.mag;
     const tsunami = e.features[0].properties.tsunami === 1 ? "yes" : "no";
 
@@ -99,7 +100,7 @@ map.on("load", () => {
       }
     }
 
-    new mapboxgl.Popup().setLngLat(coordinates).setHTML(`magnitude: ${mag}<br>Was there a tsunami?: ${tsunami}`).addTo(map);
+    // new mapboxgl.Popup().setLngLat(coordinates).setHTML(`magnitude: ${mag}<br>Was there a tsunami?: ${tsunami}`).addTo(map);
   });
 
   map.on("mouseenter", "clusters", () => {

--- a/public/js/clusterMap.js
+++ b/public/js/clusterMap.js
@@ -13,11 +13,11 @@ map.on("load", () => {
   // Add a new source from our GeoJSON data and
   // set the 'cluster' option to true. GL-JS will
   // add the point_count property to your source data.
-  map.addSource("earthquakes", {
+  map.addSource("campgrounds", {
     type: "geojson",
     // Point to GeoJSON data. This example visualizes all M1.0+ earthquakes
     // from 12/22/15 to 1/21/16 as logged by USGS' Earthquake hazards program.
-    data: "https://docs.mapbox.com/mapbox-gl-js/assets/earthquakes.geojson",
+    data: allCampgroundsGeoJsonData, // this data comes from the variable define in index.ejs
     cluster: true,
     clusterMaxZoom: 14, // Max zoom to cluster points on
     clusterRadius: 50, // Radius of each cluster when clustering points (defaults to 50)
@@ -26,7 +26,7 @@ map.on("load", () => {
   map.addLayer({
     id: "clusters",
     type: "circle",
-    source: "earthquakes",
+    source: "campgrounds",
     filter: ["has", "point_count"],
     paint: {
       // Use step expressions (https://docs.mapbox.com/style-spec/reference/expressions/#step)
@@ -42,7 +42,7 @@ map.on("load", () => {
   map.addLayer({
     id: "cluster-count",
     type: "symbol",
-    source: "earthquakes",
+    source: "campgrounds",
     filter: ["has", "point_count"],
     layout: {
       "text-field": ["get", "point_count_abbreviated"],
@@ -54,7 +54,7 @@ map.on("load", () => {
   map.addLayer({
     id: "unclustered-point",
     type: "circle",
-    source: "earthquakes",
+    source: "campgrounds",
     filter: ["!", ["has", "point_count"]],
     paint: {
       "circle-color": "#11b4da",
@@ -70,7 +70,7 @@ map.on("load", () => {
       layers: ["clusters"],
     });
     const clusterId = features[0].properties.cluster_id;
-    map.getSource("earthquakes").getClusterExpansionZoom(clusterId, (err, zoom) => {
+    map.getSource("campgrounds").getClusterExpansionZoom(clusterId, (err, zoom) => {
       if (err) return;
 
       map.easeTo({
@@ -85,6 +85,7 @@ map.on("load", () => {
   // the location of the feature, with
   // description HTML from its properties.
   map.on("click", "unclustered-point", (e) => {
+    console.log(e.features);
     const coordinates = e.features[0].geometry.coordinates.slice();
     const mag = e.features[0].properties.mag;
     const tsunami = e.features[0].properties.tsunami === 1 ? "yes" : "no";

--- a/public/js/clusterMap.js
+++ b/public/js/clusterMap.js
@@ -85,11 +85,12 @@ map.on("load", () => {
   // the location of the feature, with
   // description HTML from its properties.
   map.on("click", "unclustered-point", (e) => {
+    // console.log(e.features[0].properties);
     console.log(e.features);
     const coordinates = e.features[0].geometry.coordinates.slice();
-
-    const mag = e.features[0].properties.mag;
-    const tsunami = e.features[0].properties.tsunami === 1 ? "yes" : "no";
+    const campgroundId = e.features[0].properties.id;
+    const campgroundTitle = e.features[0].properties.title;
+    const campgroundLocation = e.features[0].properties.location;
 
     // Ensure that if the map is zoomed out such that
     // multiple copies of the feature are visible, the
@@ -100,7 +101,15 @@ map.on("load", () => {
       }
     }
 
-    // new mapboxgl.Popup().setLngLat(coordinates).setHTML(`magnitude: ${mag}<br>Was there a tsunami?: ${tsunami}`).addTo(map);
+    // new mapboxgl.Popup().setLngLat(coordinates).setHTML(`: ${mag}<br>Was there a tsunami?: ${tsunami}`).addTo(map);
+    new mapboxgl.Popup()
+      .setLngLat(coordinates)
+      .setHTML(
+        `<b><a href="/campgrounds/${campgroundId}">${campgroundTitle}</a></b>
+        <br>
+        <p>${campgroundLocation}</p>`
+      )
+      .addTo(map);
   });
 
   map.on("mouseenter", "clusters", () => {

--- a/public/js/clusterMap.js
+++ b/public/js/clusterMap.js
@@ -1,0 +1,110 @@
+// JavaScript for creating and styling Mapbox cluster map
+
+mapboxgl.accessToken = mapToken;
+const map = new mapboxgl.Map({
+  container: "map",
+  // Choose from Mapbox's core styles, or make your own style with Mapbox Studio
+  style: "mapbox://styles/mapbox/dark-v11",
+  center: [-103.5917, 40.6699],
+  zoom: 3,
+});
+
+map.on("load", () => {
+  // Add a new source from our GeoJSON data and
+  // set the 'cluster' option to true. GL-JS will
+  // add the point_count property to your source data.
+  map.addSource("earthquakes", {
+    type: "geojson",
+    // Point to GeoJSON data. This example visualizes all M1.0+ earthquakes
+    // from 12/22/15 to 1/21/16 as logged by USGS' Earthquake hazards program.
+    data: "https://docs.mapbox.com/mapbox-gl-js/assets/earthquakes.geojson",
+    cluster: true,
+    clusterMaxZoom: 14, // Max zoom to cluster points on
+    clusterRadius: 50, // Radius of each cluster when clustering points (defaults to 50)
+  });
+
+  map.addLayer({
+    id: "clusters",
+    type: "circle",
+    source: "earthquakes",
+    filter: ["has", "point_count"],
+    paint: {
+      // Use step expressions (https://docs.mapbox.com/style-spec/reference/expressions/#step)
+      // with three steps to implement three types of circles:
+      //   * Blue, 20px circles when point count is less than 100
+      //   * Yellow, 30px circles when point count is between 100 and 750
+      //   * Pink, 40px circles when point count is greater than or equal to 750
+      "circle-color": ["step", ["get", "point_count"], "#51bbd6", 100, "#f1f075", 750, "#f28cb1"],
+      "circle-radius": ["step", ["get", "point_count"], 20, 100, 30, 750, 40],
+    },
+  });
+
+  map.addLayer({
+    id: "cluster-count",
+    type: "symbol",
+    source: "earthquakes",
+    filter: ["has", "point_count"],
+    layout: {
+      "text-field": ["get", "point_count_abbreviated"],
+      "text-font": ["DIN Offc Pro Medium", "Arial Unicode MS Bold"],
+      "text-size": 12,
+    },
+  });
+
+  map.addLayer({
+    id: "unclustered-point",
+    type: "circle",
+    source: "earthquakes",
+    filter: ["!", ["has", "point_count"]],
+    paint: {
+      "circle-color": "#11b4da",
+      "circle-radius": 4,
+      "circle-stroke-width": 1,
+      "circle-stroke-color": "#fff",
+    },
+  });
+
+  // inspect a cluster on click
+  map.on("click", "clusters", (e) => {
+    const features = map.queryRenderedFeatures(e.point, {
+      layers: ["clusters"],
+    });
+    const clusterId = features[0].properties.cluster_id;
+    map.getSource("earthquakes").getClusterExpansionZoom(clusterId, (err, zoom) => {
+      if (err) return;
+
+      map.easeTo({
+        center: features[0].geometry.coordinates,
+        zoom: zoom,
+      });
+    });
+  });
+
+  // When a click event occurs on a feature in
+  // the unclustered-point layer, open a popup at
+  // the location of the feature, with
+  // description HTML from its properties.
+  map.on("click", "unclustered-point", (e) => {
+    const coordinates = e.features[0].geometry.coordinates.slice();
+    const mag = e.features[0].properties.mag;
+    const tsunami = e.features[0].properties.tsunami === 1 ? "yes" : "no";
+
+    // Ensure that if the map is zoomed out such that
+    // multiple copies of the feature are visible, the
+    // popup appears over the copy being pointed to.
+    if (["mercator", "equirectangular"].includes(map.getProjection().name)) {
+      while (Math.abs(e.lngLat.lng - coordinates[0]) > 180) {
+        coordinates[0] += e.lngLat.lng > coordinates[0] ? 360 : -360;
+      }
+    }
+
+    new mapboxgl.Popup().setLngLat(coordinates).setHTML(`magnitude: ${mag}<br>Was there a tsunami?: ${tsunami}`).addTo(map);
+  });
+
+  map.on("mouseenter", "clusters", () => {
+    map.getCanvas().style.cursor = "pointer";
+  });
+  map.on("mouseleave", "clusters", () => {
+    map.getCanvas().style.cursor = "";
+  });
+});

--- a/seeds/index.js
+++ b/seeds/index.js
@@ -46,7 +46,7 @@ const seedDB = async () => {
       location: `${cities[random1000].city}, ${cities[random1000].state}`,
       geometry: {
         type: "Point",
-        coordinates: [-72.608648, 40.908815],
+        coordinates: [cities[random1000].longitude, cities[random1000].latitude],
       },
       title: `${sample(descriptors)} ${sample(places)}`,
       // image: randomImageURLs.regular,

--- a/seeds/index.js
+++ b/seeds/index.js
@@ -19,25 +19,27 @@ async function main() {
 const sample = (array) => array[Math.floor(Math.random() * array.length)];
 
 // function to return a random image from a collection using the Unsplash API
-const seedRandomImg = async () => {
-  try {
-    const response = await axios.get(`https://api.unsplash.com/collections/9046579/photos/?client_id=${accessKey}`);
-    const unsplashObjectsArray = response.data;
-    const randomImgObject = sample(unsplashObjectsArray);
-    const imgURLs = randomImgObject.urls;
-    // console.log(imgURLs);
-    return imgURLs;
-  } catch (error) {
-    console.log("Error fetching image:", error);
-  }
-};
+// Commented out because I made images an array of image objects - so each image
+// has a url and filename. These are hardcoded for simplicity, so seedRandomImg() isn't needed right now
+// const seedRandomImg = async () => {
+//   try {
+//     const response = await axios.get(`https://api.unsplash.com/collections/9046579/photos/?client_id=${accessKey}`);
+//     const unsplashObjectsArray = response.data;
+//     const randomImgObject = sample(unsplashObjectsArray);
+//     const imgURLs = randomImgObject.urls;
+//     // console.log(imgURLs);
+//     return imgURLs;
+//   } catch (error) {
+//     console.log("Error fetching image:", error);
+//   }
+// };
 
 // Remove everything from DB first, then seed it
 const seedDB = async () => {
   await Campground.deleteMany({});
 
   // loop through 8 times to create 8 new random campgrounds
-  for (let i = 0; i < 8; i++) {
+  for (let i = 0; i < 250; i++) {
     const random1000 = Math.floor(Math.random() * 1000) + 1;
     // const randomImageURLs = await seedRandomImg();
     const price = Math.floor(Math.random() * 21) + 10; // random price b/w 10-30

--- a/views/campgrounds/index.ejs
+++ b/views/campgrounds/index.ejs
@@ -7,9 +7,9 @@
   // Use JSON.parse to convert the string back into a JavaScript object
   const campgrounds = JSON.parse(`<%- JSON.stringify(allCampgrounds) %>`);
 
-  // Convert the campgrounds array into a GeoJSON FeatureCollection
-  // This structure is required for Mapbox clustering functionality, similar to the example provided here:
-  // https://docs.mapbox.com/mapbox-gl-js/assets/earthquakes.geojson
+  // // Convert the campgrounds array into a GeoJSON FeatureCollection
+  // // This structure is required for Mapbox clustering functionality, similar to the example provided here:
+  // // https://docs.mapbox.com/mapbox-gl-js/assets/earthquakes.geojson
   const allCampgroundsGeoJsonData = {
     type: "FeatureCollection",
     features: campgrounds.map((campground) => {
@@ -32,6 +32,13 @@
       };
     }),
   };
+
+  // Directly embed the campgrounds data as GeoJSON
+  // THIS IS MORE SIMPLE THAN THE ABOVE, BUT THERE'S ISSUE WITH THE EJS WARNING
+  // Can't get rid of ejs warning, so chose to parse and then convert
+  // Below, because comments wouldn't comment it out, if using in the future,
+  // add the EJS tag output escape on JSON.stringify(allCampgrounds)
+  // const allCampgroundsGeoJsonData = { features: JSON.stringify(allCampgrounds)  };
 </script>
 
 <div id="map" class="mb-3" style="width: 100%; height: 500px"></div>

--- a/views/campgrounds/index.ejs
+++ b/views/campgrounds/index.ejs
@@ -3,6 +3,35 @@
 <script>
   // Retrieve the Mapbox public token from the environment variables
   const mapToken = `<%- process.env.MAPBOX_PUBLIC_TOKEN %>`;
+  // Retrieve the campground object and convert it to a JSON string
+  // Use JSON.parse to convert the string back into a JavaScript object
+  const campgrounds = JSON.parse(`<%- JSON.stringify(allCampgrounds) %>`);
+
+  // Convert the campgrounds array into a GeoJSON FeatureCollection
+  // This structure is required for Mapbox clustering functionality, similar to the example provided here:
+  // https://docs.mapbox.com/mapbox-gl-js/assets/earthquakes.geojson
+  const allCampgroundsGeoJsonData = {
+    type: "FeatureCollection",
+    features: campgrounds.map((campground) => {
+      return {
+        type: "Feature",
+        geometry: {
+          type: "Point",
+          coordinates: campground.geometry.coordinates, // [longitude, latitude]
+        },
+        properties: {
+          id: campground._id,
+          title: campground.title,
+          author: campground.author,
+          description: campground.description,
+          location: campground.location,
+          price: campground.price,
+          images: campground.images,
+          reviews: campground.reviews,
+        },
+      };
+    }),
+  };
 </script>
 
 <div id="map" class="mb-3" style="width: 100%; height: 500px"></div>

--- a/views/campgrounds/index.ejs
+++ b/views/campgrounds/index.ejs
@@ -1,4 +1,11 @@
 <% layout('/layouts/boilerplate') %>
+
+<script>
+  // Retrieve the Mapbox public token from the environment variables
+  const mapToken = `<%- process.env.MAPBOX_PUBLIC_TOKEN %>`;
+</script>
+
+<div id="map" class="mb-3" style="width: 100%; height: 500px"></div>
 <h1>All Campgrounds 🏕️</h1>
 
 <a href="/campgrounds/new">
@@ -23,10 +30,12 @@
         <p class="card-text">
           <small class="text-body-secondary"><%= camp.location %></small>
         </p>
-        <a href="/campgrounds/<%= camp._id %>" class="btn btn-primary">View Campground</a>
+        <a href="/campgrounds/<%= camp._id %>" class="btn btn-primary">View <%= camp.title %></a>
       </div>
     </div>
   </div>
 </div>
 
 <% } %>
+
+<script src="/js/clusterMap.js"></script>


### PR DESCRIPTION
This merge introduces a comprehensive cluster map feature for displaying campground locations, enhancing the map visualization and user interaction on the campgrounds index page.

**Key Features**

_Initial Earthquake Cluster Map and Seed Data Update_

- Added an earthquake cluster map example from Mapbox documentation to the campgrounds index page.

- Updated seed data with latitude and longitude coordinates for campgrounds.

- Reseeded the database with updated coordinates.

_Basic Clustering for Campgrounds_

- Implemented clustering for campground locations on the map using Mapbox.

- Converted the campgrounds array into a GeoJSON FeatureCollection to match the structure used in the Mapbox earthquake example.

- Updated map.addSource('earthquakes') to map.addSource('campgrounds') to use the new campground data source.

_Added a Few Comments and Commented Out Unused Code_

- Added comments for future reference.

- Commented out the seedRandomImg() function since campground image objects have a hardcoded URL and filename property.

_Changed Cluster Size and Color_

- Updated cluster size and color based on the number of campgrounds in each cluster.

- Changed map style from dark-v11 to light-v11.

_Customize Popups for Campgrounds on Cluster Map_

- Customized popups for each campground on the cluster map.

- For unclustered points, when clicked, the campground name displays as a clickable link with the campground location shown underneath.

- Earlier, I converted the allCampgrounds array into a GeoJSON FeatureCollection to match the expected format by Mapbox for clustering functionality - an alternative, which I considered but did not implement, was to create a virtual property on the campground schema for clustering (this could be changed in the future, if needed).